### PR TITLE
Add internal IP to webhook

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,6 +63,7 @@ services:
     restart: unless-stopped
     environment:
       - "TZ=Asia/Tehran"
+      - "GITEA__webhook__ALLOWED_HOST_LIST=*"
     volumes:
       - "gitea_data:/data"
     ports:


### PR DESCRIPTION
To connect to jenkins local, it gave the following error:
webhook can only call allowed HTTP servers